### PR TITLE
Comment out line-12 of "changelog.gradle".

### DIFF
--- a/scripts/both/changelog.gradle
+++ b/scripts/both/changelog.gradle
@@ -8,9 +8,9 @@ buildscript {
     classpath "gradle.plugin.se.bjurr.gitchangelog:git-changelog-gradle-plugin:1.50"
   }
 }
-
-apply plugin: "se.bjurr.gitchangelog.git-changelog-gradle-plugin"
-
+/**
+ * apply plugin: "se.bjurr.gitchangelog.git-changelog-gradle-plugin"
+ */
 /**
  * Generates a Bamboo XML changelog via the REST API.
  */


### PR DESCRIPTION
Apparently, this line causes issues with Travis builds of "AI-Improvements". 

<details><summary>Travis-CI Log Excerpt:</summary><p>

```
Caused by: org.gradle.api.plugins.UnknownPluginException: Plugin with id 'se.bjurr.gitchangelog.git-changelog-gradle-plugin' not found.
	at org.gradle.api.internal.plugins.DefaultPluginManager.apply(DefaultPluginManager.java:110)
	at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.applyType(DefaultObjectConfigurationAction.java:112)
	at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.access$200(DefaultObjectConfigurationAction.java:35)
	at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction$3.run(DefaultObjectConfigurationAction.java:79)
	at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.execute(DefaultObjectConfigurationAction.java:135)
	at org.gradle.groovy.scripts.DefaultScript.apply(DefaultScript.java:109)
	at org.gradle.api.Script$apply$0.callCurrent(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:49)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
	at changelog_edg9yvpngy2tej8k5k5d97v8d.run(https://raw.githubusercontent.com/BuiltBrokenModding/BuiltBrokenScripts/universal/scripts/both/changelog.gradle:12)
	at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:91)
```

</p></details>

See [<https://travis-ci.org/LordNyriox/AI-Improvements>] for details.